### PR TITLE
Add a link to the mail to prefill the form with previous data

### DIFF
--- a/project/apps/orderform/forms.py
+++ b/project/apps/orderform/forms.py
@@ -2,8 +2,10 @@ from email.mime.text import MIMEText
 
 from django.conf import settings
 from django.core.mail import EmailMessage
+from django.core.signing import dumps
 from django.forms import Form, CharField, EmailField
 from django.template import loader
+from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
@@ -13,6 +15,10 @@ import yaml
 class OrderForm(Form):
     product_name = CharField(label=_("Product Name"))
     main_email = EmailField(label=_("E-Mail Address"))
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super().__init__(*args, **kwargs)
 
     @property
     def yaml_filename(self):
@@ -32,8 +38,15 @@ class OrderForm(Form):
         return [self.yaml]
 
     @property
+    def redo_url(self):
+        url = reverse("order_prefilled", args=(dumps(self.data),))
+        if self.request:
+            url = self.request.build_absolute_uri(url)
+        return url
+
+    @property
     def context(self):
-        return {"data": self.cleaned_data}
+        return {"data": self.cleaned_data, "redo_url": self.redo_url}
 
     @property
     def body(self):

--- a/project/apps/orderform/forms.py
+++ b/project/apps/orderform/forms.py
@@ -16,6 +16,8 @@ class OrderForm(Form):
     product_name = CharField(label=_("Product Name"))
     main_email = EmailField(label=_("E-Mail Address"))
 
+    SALT = "orderform"
+
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request")
         super().__init__(*args, **kwargs)
@@ -39,7 +41,9 @@ class OrderForm(Form):
 
     @property
     def redo_url(self):
-        url = reverse("order_prefilled", args=(dumps(self.data),))
+        url = reverse(
+            "order_prefilled", args=(dumps(self.data, compress=True, salt=self.SALT),)
+        )
         if self.request:
             url = self.request.build_absolute_uri(url)
         return url

--- a/project/apps/orderform/templates/orderform/order_mail_body.txt
+++ b/project/apps/orderform/templates/orderform/order_mail_body.txt
@@ -2,5 +2,8 @@ There is a new order:
 
 {% for field,value in data.items %}{{ field }}: {{ value }}
 {% endfor %}
+
+To prefill the form again with those values, visit: {{ redo_url }}
+
 Best Regards,
 Your order form

--- a/project/apps/orderform/tests/test_orderform.py
+++ b/project/apps/orderform/tests/test_orderform.py
@@ -1,6 +1,8 @@
 from django.core import mail
 from django.urls import reverse
 
+from ..forms import OrderForm
+
 
 def test_form_sends_mail(client):
     response = client.post(
@@ -9,3 +11,14 @@ def test_form_sends_mail(client):
 
     assert len(mail.outbox) == 1  # nosec
     assert "foo@example.com" in mail.outbox[0].subject  # nosec
+
+
+def test_redo_url(client):
+    """
+    Generate a redo url with one field filled.
+    Verify the field will be prefilled when loading the redo_url for this form.
+    """
+    redo_url = OrderForm(request=None, data={"product_name": "Test Product"}).redo_url
+    response = client.get(redo_url)
+
+    assert b"Test Product" in response.content  # nosec

--- a/project/apps/orderform/urls.py
+++ b/project/apps/orderform/urls.py
@@ -4,5 +4,6 @@ from .views import OrderCompleteView, OrderView
 
 urlpatterns = [
     path("", OrderView.as_view(), name="order"),
+    path("prefill/<data>/", OrderView.as_view(), name="order_prefilled"),
     path("success/", OrderCompleteView.as_view(), name="order_complete"),
 ]

--- a/project/apps/orderform/views.py
+++ b/project/apps/orderform/views.py
@@ -18,7 +18,7 @@ class OrderView(FormView):
         if "data" not in self.kwargs:
             return super().get_initial()
 
-        return loads(self.kwargs["data"])
+        return loads(self.kwargs["data"], salt=OrderForm.SALT)
 
     def get_form_kwargs(self):
         rv = super().get_form_kwargs()

--- a/project/apps/orderform/views.py
+++ b/project/apps/orderform/views.py
@@ -1,3 +1,4 @@
+from django.core.signing import loads
 from django.urls import reverse_lazy
 from django.views.generic import FormView, TemplateView
 
@@ -12,6 +13,17 @@ class OrderView(FormView):
     form_class = OrderForm
     template_name = "orderform/order.html"
     success_url = reverse_lazy("order_complete")
+
+    def get_initial(self):
+        if "data" not in self.kwargs:
+            return super().get_initial()
+
+        return loads(self.kwargs["data"])
+
+    def get_form_kwargs(self):
+        rv = super().get_form_kwargs()
+        rv["request"] = self.request
+        return rv
 
     def form_valid(self, form):
         form.save()


### PR DESCRIPTION
It would be nice for our customers to be able to prefill the form
again with the data they entered previously if they need to make
any modifications, so that they do not have to re-enter everything.