### PR TITLE
Renovate/CircleCI: Autopush fixes

### DIFF
--- a/bin/ci-requirements.sh
+++ b/bin/ci-requirements.sh
@@ -11,8 +11,8 @@ case "${CIRCLE_BRANCH}" in
 	;;
 esac
 
-git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-git config --global user.name "$CIRCLE_USERNAME"
+git config --global user.email "circleci@westnetz.org"
+git config --global user.name "Westnetz CircleCI"
 make update-requirements
 if [ -z "$(git status --porcelain)" ]; then
 	exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base", "docker:enableMajor"],
   "labels": ["renovate"],
   "pip_requirements": {
-    "fileMatch": ["(^|/)requirements.*\\.in$"]
+    "fileMatch": ["(^|/)requirements.*\\.in$"],
+    "ignorePaths": ["*.txt"]
   }
 }


### PR DESCRIPTION
Set a username for git which is always usable.
Ignore .txt files for renovate.